### PR TITLE
Release 0.8.0. Breaking fixes to Stream.ToBytes and Stream.ToBytesAsync.

### DIFF
--- a/src/OwlCore.Extensions.csproj
+++ b/src/OwlCore.Extensions.csproj
@@ -14,13 +14,20 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.7.0</Version>
+		<Version>0.8.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A collection of exceptionally useful extension methods.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Extensions</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.8.0 ---
+[Breaking]
+The Stream.ToBytes and Stream.ToBytesAsync method no longer try to read position or seek the stream internally. Instead, rewind the stream before using this extension method. This allows us to support non-seekable streams.
+
+[Improvements]
+Stream.ToBytesAsync now properly takes a cancellation token for the second parameter.
+
 --- 0.7.0 ---
 [Breaking]
 Inherited breaking changes from OwlCore.ComponentModel 0.7.0. Removes transient dependency on OwlCore.Storage.
@@ -117,6 +124,6 @@ OwlCore.Validation.Mime.MimeTypeMap functionality has been moved to extension me
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.7.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.8.0" />
 	</ItemGroup>
 </Project>

--- a/src/StreamExtensions/ToBytes.cs
+++ b/src/StreamExtensions/ToBytes.cs
@@ -32,7 +32,7 @@ namespace OwlCore.Extensions
         public static async Task<byte[]> ToBytesAsync(this Stream input, CancellationToken cancellationToken = default)
         {
             using var memStream = new MemoryStream();
-            await input.CopyToAsync(memStream, cancellationToken);
+            await input.CopyToAsync(memStream, 81920, cancellationToken);
             return memStream.ToArray();
         }
     }

--- a/src/StreamExtensions/ToBytes.cs
+++ b/src/StreamExtensions/ToBytes.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
@@ -14,51 +14,25 @@ namespace OwlCore.Extensions
         /// Converts the <paramref name="input"/> <see cref="Stream"/> to a byte array.
         /// </summary>
         /// <remarks>
-        /// The method will seek to the start of the stream, read (and copy into a MemoryStream) until it runs out of data. It then asks the MemoryStream to return a copy of the data in an array.
+        /// The method will read and copy into a MemoryStream until it runs out of data. It then asks the MemoryStream to return a copy of the data in an array.
         /// </remarks>
         public static byte[] ToBytes(this Stream input)
         {
-            var originalPosition = input.Position;
-            if (input.Position != 0)
-            {
-                if (input.CanSeek)
-                    input.Position = 0;
-                else
-                    throw new ArgumentException("Stream is not at position 0 and is unable to seek.", nameof(input));
-            }
-
             using var memStream = new MemoryStream();
             input.CopyTo(memStream);
-
-            if (input.CanSeek)
-                input.Position = originalPosition;
-
             return memStream.ToArray();
         }
 
         /// <summary>
-        /// Converts the <paramref name="input"/> <see cref="Stream"/> to a byte array.
+        /// Converts the <paramref name="input"/> <see cref="Stream"/> to a byte array asynchronously.
         /// </summary>
         /// <remarks>
-        /// The method will seek to the start of the stream, read (and copy into a MemoryStream) until it runs out of data. It then asks the MemoryStream to return a copy of the data in an array.
+        /// The method will read and copy into a MemoryStream until it runs out of data. It then asks the MemoryStream to return a copy of the data in an array.
         /// </remarks>
-        public static async Task<byte[]> ToBytesAsync(this Stream input)
+        public static async Task<byte[]> ToBytesAsync(this Stream input, CancellationToken cancellationToken = default)
         {
-            var originalPosition = input.Position;
-            if (input.Position != 0)
-            {
-                if (input.CanSeek)
-                    input.Position = 0;
-                else
-                    throw new ArgumentException("Stream is not at position 0 and is unable to seek.", nameof(input));
-            }
-
             using var memStream = new MemoryStream();
-            await input.CopyToAsync(memStream);
-
-            if (input.CanSeek)
-                input.Position = originalPosition;
-
+            await input.CopyToAsync(memStream, cancellationToken);
             return memStream.ToArray();
         }
     }

--- a/tests/OwlCore.Extensions.Tests.csproj
+++ b/tests/OwlCore.Extensions.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
[Breaking]
The Stream.ToBytes and Stream.ToBytesAsync method no longer try to read position or seek the stream internally. Instead, rewind the stream before using this extension method. This allows us to support non-seekable streams.

[Improvements]
Stream.ToBytesAsync now properly takes a cancellation token for the second parameter.