### PR TITLE
Add net9.0 and net10.0 target frameworks, condition async compat packages, update OwlCore.ComponentModel to 0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install .NET SDK
+      - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/src/OwlCore.Extensions.csproj
+++ b/src/OwlCore.Extensions.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<LangVersion>10.0</LangVersion>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
@@ -136,10 +136,10 @@ OwlCore.Validation.Mime.MimeTypeMap functionality has been moved to extension me
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     	<PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.1" />
-    	<PackageReference Include="OwlCore.ComponentModel" Version="0.9.1" />
+    	<PackageReference Include="OwlCore.ComponentModel" Version="0.11.0" />
 	</ItemGroup>
 </Project>

--- a/tests/OwlCore.Extensions.Tests.csproj
+++ b/tests/OwlCore.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Adds `net9.0` and `net10.0` to `TargetFrameworks` (previously only `netstandard2.0;net8.0`).

`System.Linq.Async` and `Microsoft.Bcl.AsyncInterfaces` are now conditioned with `!IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')` so they are excluded on net10.0+ where these APIs are built into the runtime.

Updates `OwlCore.ComponentModel` from `0.9.1` to `0.11.0`.

No version bump in this PR.
