### PR TITLE
Release 0.11.0

### DIFF
--- a/src/OwlCore.Extensions.csproj
+++ b/src/OwlCore.Extensions.csproj
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.10.0</Version>
+		<Version>0.11.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A collection of exceptionally useful extension methods.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Extensions</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.11.0 ---
+[Improvements]
+Added net9.0 and net10.0 as target frameworks. System.Linq.Async and Microsoft.Bcl.AsyncInterfaces are now conditioned to exclude net10.0+, where these APIs are built into the runtime.
+
 --- 0.10.0 ---
 [New]
 Add StreamExtensions with synchronous and asynchronous text writing methods.


### PR DESCRIPTION
Bumps version to `0.11.0` and adds release notes.

Depends on #3 merging first.