### PR TITLE
Update CI workflows for net9.0 and net10.0 target frameworks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install .NET SDK
+      - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/tests/OwlCore.Extensions.Tests.csproj
+++ b/tests/OwlCore.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Updates both CI workflow files to use .NET 10 SDK, replacing the previously pinned .NET 8 SDK.

## Changes

### .github/workflows/build.yml
- Renamed step from Install .NET SDK to Install .NET 10 SDK
- Updated dotnet-version from 8.0.x to 10.0.x

### .github/workflows/publish.yml
- Updated dotnet-version from 8.0.x to 10.0.x

These changes ensure CI builds and publishes against the .NET 10 SDK, aligning with the 
et9.0 and 
et10.0 TFMs being added to the project.